### PR TITLE
chore(deps): update vizdom dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@ng-doc/builder": "17.6.8",
         "@ng-doc/core": "17.6.8",
         "@ng-doc/ui-kit": "17.6.8",
-        "@vizdom/vizdom-ts-web": "0.1.3",
+        "@vizdom/vizdom-ts-web": "0.1.19",
         "d3-drag": "^3.0.0",
         "d3-force": "^3.0.0",
         "d3-selection": "^3.0.0",
@@ -6654,9 +6654,10 @@
       }
     },
     "node_modules/@vizdom/vizdom-ts-web": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@vizdom/vizdom-ts-web/-/vizdom-ts-web-0.1.3.tgz",
-      "integrity": "sha512-SB/WDcxxUrXrLSnIgBNdvoTk9hvZZXdnIiPbvl8aGDIJr7xX+vFvBy7zpHCl3+2YWoDapMG9mjraZlRG19YJtQ=="
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@vizdom/vizdom-ts-web/-/vizdom-ts-web-0.1.19.tgz",
+      "integrity": "sha512-Cjl4wn9oodoKUAeDUeiBg746h+ibTQcPpobI2kID83pBFuAvuXg4tvtLo5LQKtyCjJEjy96b2P2GmIq1wd4ZVg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ng-doc/builder": "17.6.8",
     "@ng-doc/core": "17.6.8",
     "@ng-doc/ui-kit": "17.6.8",
-    "@vizdom/vizdom-ts-web": "0.1.3",
+    "@vizdom/vizdom-ts-web": "0.1.19",
     "d3-drag": "^3.0.0",
     "d3-force": "^3.0.0",
     "d3-selection": "^3.0.0",

--- a/projects/ngx-vflow-demo/src/app/categories/workshops/categories/layout/pages/vizdom-layout/demo/vizdom-layout-demo.component.ts
+++ b/projects/ngx-vflow-demo/src/app/categories/workshops/categories/layout/pages/vizdom-layout/demo/vizdom-layout-demo.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit, signal, viewChild, WritableSignal } from '@angular/core';
-import init, { DirectedGraph, VertexRef } from '@vizdom/vizdom-ts-web';
-import { Edge, Node, VflowComponent, Vflow } from 'ngx-vflow';
+import init, { DirectedGraph, VertexWeakRef } from '@vizdom/vizdom-ts-web';
+import { Edge, Node, Vflow, VflowComponent } from 'ngx-vflow';
 
 @Component({
   templateUrl: './vizdom-layout-demo.component.html',
@@ -83,9 +83,9 @@ export class VizdomLayoutDemoComponent implements OnInit {
       },
     });
 
-    // DirectedGraph not provide VErtexRef ids so we need to store it somewhere
+    // DirectedGraph not provide VertexWeakRef ids so we need to store it somewhere
     // for later access
-    const vertices = new Map<string, VertexRef>();
+    const vertices = new Map<string, VertexWeakRef>();
     const nodes = new Map<string, Node>();
 
     nodesToLayout.forEach((n) => {
@@ -120,8 +120,8 @@ export class VizdomLayoutDemoComponent implements OnInit {
     this.nodes.set(
       layout.nodes.map((n) => {
         return {
-          ...nodes.get(n.id)!,
-          id: n.id,
+          ...nodes.get(n.id!)!,
+          id: n.id!,
           point: {
             x: n.x,
             y: n.y,


### PR DESCRIPTION
I attempted to take a look at the code in ngx-vflow and noticed when the handler is failed to be called (i.e. appears to do nothing), some of the child node's update their `transform` attribute. The subsequent click triggers the handler as outlined in #127. 

While this does not fix the underlying issue, the latest version of Vizdom avoids memory leaks when the app holds references to nodes and edges after the graph is dropped.