### PR TITLE
feat: add a grid pattern background

### DIFF
--- a/projects/ngx-vflow-lib/src/lib/vflow/components/alignment-helper/alignment-helper.component.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/components/alignment-helper/alignment-helper.component.ts
@@ -7,7 +7,6 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { filter, map, tap } from 'rxjs';
 import { extendedComputed } from '../../utils/signals/extended-computed';
 import { NodeRenderingService } from '../../services/node-rendering.service';
-import { getSpacePoints } from '../../utils/get-space-points';
 
 interface Intersection {
   lines: (Box & { isCenter: boolean })[];
@@ -124,9 +123,16 @@ export class AlignmentHelperComponent {
         tap(([node, intersections]) => {
           if (intersections) {
             const snapped = { x: intersections.snappedX, y: intersections.snappedY };
-            const parentIfExists = node.parent() ? [node.parent()!] : [];
 
-            node.setPoint(getSpacePoints(snapped, parentIfExists)[0]);
+            const parent = node.parent();
+            if (parent) {
+              node.setPoint({
+                x: snapped.x - parent.globalPoint().x,
+                y: snapped.y - parent.globalPoint().y,
+              });
+            } else {
+              node.setPoint(snapped);
+            }
           }
         }),
         takeUntilDestroyed(),

--- a/projects/ngx-vflow-lib/src/lib/vflow/components/background/background.component.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/components/background/background.component.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
-import { ViewportService } from '../../services/viewport.service';
-import { RootSvgReferenceDirective } from '../../directives/reference.directive';
-import { id } from '../../utils/id';
-import { FlowSettingsService } from '../../services/flow-settings.service';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { map, switchMap } from 'rxjs';
+import { RootSvgReferenceDirective } from '../../directives/reference.directive';
+import { FlowSettingsService } from '../../services/flow-settings.service';
+import { ViewportService } from '../../services/viewport.service';
+import { id } from '../../utils/id';
 import { toLazySignal } from '../../utils/signals/to-lazy-signal';
 
 const defaultBg = '#fff';
@@ -30,21 +30,11 @@ export class BackgroundComponent {
   protected backgroundSignal = this.settingsService.background;
 
   protected x = computed(() => {
-    const background = this.backgroundSignal();
-
-    return (
-      this.viewportService.readableViewport().x %
-      (background?.type === 'grid' ? (background.size ?? defaultGridSize) : this.scaledGap())
-    );
+    return this.viewportService.readableViewport().x % this.scaledGap();
   });
 
   protected y = computed(() => {
-    const background = this.backgroundSignal();
-
-    return (
-      this.viewportService.readableViewport().y %
-      (background?.type === 'grid' ? (background.size ?? defaultGridSize) : this.scaledGap())
-    );
+    return this.viewportService.readableViewport().y % this.scaledGap();
   });
 
   protected patternColor = computed(() => {
@@ -65,20 +55,22 @@ export class BackgroundComponent {
     }
 
     if (background.type === 'grid') {
-      return (this.viewportService.readableViewport().zoom * (background.size ?? defaultGridSize)) / 2;
+      return (this.viewportService.readableViewport().zoom * (background.strokeWidth ?? defaultGridSize)) / 2;
     }
 
     return 0;
   });
 
-  // DOTS PATTERN
   protected scaledGap = computed(() => {
     const background = this.backgroundSignal();
+    const zoom = this.viewportService.readableViewport().zoom;
 
     if (background.type === 'dots') {
-      const zoom = this.viewportService.readableViewport().zoom;
-
       return zoom * (background.gap ?? defaultGap);
+    }
+
+    if (background.type === 'grid') {
+      return zoom * (background.size ?? defaultGridSize);
     }
 
     return 0;
@@ -89,7 +81,8 @@ export class BackgroundComponent {
     const background = this.backgroundSignal();
 
     if (background.type === 'grid') {
-      return (this.viewportService.readableViewport().zoom * (background.strokeWidth ?? defaultStrokeWidth)) / 2;
+      const zoom = this.viewportService.readableViewport().zoom;
+      return zoom * ((background.strokeWidth ?? defaultStrokeWidth) / 2);
     }
 
     return 0;
@@ -178,6 +171,10 @@ export class BackgroundComponent {
       const background = this.backgroundSignal();
 
       if (background.type === 'dots') {
+        this.rootSvg.style.backgroundColor = background.backgroundColor ?? defaultBg;
+      }
+
+      if (background.type === 'grid') {
         this.rootSvg.style.backgroundColor = background.backgroundColor ?? defaultBg;
       }
 

--- a/projects/ngx-vflow-lib/src/lib/vflow/interfaces/edge.interface.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/interfaces/edge.interface.ts
@@ -51,18 +51,18 @@ export function createEdge<T>(
   if (options.useDefaults) {
     return {
       id: edge.id,
-      type: edge.type ?? EDGE_DEFAULTS.type,
       source: edge.source,
       target: edge.target,
-      sourceHandle: edge.sourceHandle ?? '',
-      targetHandle: edge.targetHandle ?? '',
-      curve: signal(edge.curve ?? EDGE_DEFAULTS.curve),
-      data: signal(edge.data ?? EDGE_DEFAULTS.data) as WritableSignal<T>,
-      edgeLabels: signal(edge.edgeLabels ?? EDGE_DEFAULTS.edgeLabels),
-      markers: signal(edge.markers ?? EDGE_DEFAULTS.markers),
-      reconnectable: signal(edge.reconnectable ?? EDGE_DEFAULTS.reconnectable),
-      floating: signal(edge.floating ?? EDGE_DEFAULTS.floating),
-      selected: signal(edge.selected ?? EDGE_DEFAULTS.selected),
+      type: isDefined(edge.type) ? edge.type : EDGE_DEFAULTS.type,
+      sourceHandle: isDefined(edge.sourceHandle) ? edge.sourceHandle : '',
+      targetHandle: isDefined(edge.targetHandle) ? edge.targetHandle : '',
+      curve: signal(isDefined(edge.curve) ? edge.curve : EDGE_DEFAULTS.curve),
+      data: signal(isDefined(edge.data) ? edge.data : EDGE_DEFAULTS.data) as WritableSignal<T>,
+      edgeLabels: signal(isDefined(edge.edgeLabels) ? edge.edgeLabels : EDGE_DEFAULTS.edgeLabels),
+      markers: signal(isDefined(edge.markers) ? edge.markers : EDGE_DEFAULTS.markers),
+      reconnectable: signal(isDefined(edge.reconnectable) ? edge.reconnectable : EDGE_DEFAULTS.reconnectable),
+      floating: signal(isDefined(edge.floating) ? edge.floating : EDGE_DEFAULTS.floating),
+      selected: signal(isDefined(edge.selected) ? edge.selected : EDGE_DEFAULTS.selected),
     };
   } else {
     return {

--- a/projects/ngx-vflow-lib/src/lib/vflow/interfaces/node.interface.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/interfaces/node.interface.ts
@@ -13,6 +13,7 @@ export const NODE_DEFAULTS = {
   height: 50,
   draggable: true,
   parentId: null,
+  extent: 'parent' as const,
   preview: { style: {} },
   selected: false,
   color: '#1b262c',
@@ -34,6 +35,7 @@ export interface SharedNode {
   point: WritableSignal<Point>;
   draggable?: WritableSignal<boolean>;
   parentId?: WritableSignal<string | null>;
+  extent?: WritableSignal<'parent' | null>;
   preview?: WritableSignal<NodePreview>;
   selected?: WritableSignal<boolean>;
 }
@@ -127,10 +129,11 @@ function createBaseNode(node: UnwrapSignal<SharedNode>, useDefaults: boolean) {
     return {
       id: node.id,
       point: signal(node.point),
-      draggable: signal(node.draggable ?? NODE_DEFAULTS.draggable),
-      parentId: signal(node.parentId ?? NODE_DEFAULTS.parentId),
-      preview: signal(node.preview ?? NODE_DEFAULTS.preview),
-      selected: signal(node.selected ?? NODE_DEFAULTS.selected),
+      draggable: signal(isDefined(node.draggable) ? node.draggable : NODE_DEFAULTS.draggable),
+      parentId: signal(isDefined(node.parentId) ? node.parentId : NODE_DEFAULTS.parentId),
+      extent: signal(isDefined(node.extent) ? node.extent : NODE_DEFAULTS.extent),
+      preview: signal(isDefined(node.preview) ? node.preview : NODE_DEFAULTS.preview),
+      selected: signal(isDefined(node.selected) ? node.selected : NODE_DEFAULTS.selected),
     };
   } else {
     return {
@@ -138,6 +141,7 @@ function createBaseNode(node: UnwrapSignal<SharedNode>, useDefaults: boolean) {
       point: signal(node.point),
       draggable: isDefined(node.draggable) ? signal(node.draggable) : undefined,
       parentId: isDefined(node.parentId) ? signal(node.parentId) : undefined,
+      extent: isDefined(node.extent) ? signal(node.extent) : undefined,
       preview: isDefined(node.preview) ? signal(node.preview) : undefined,
       selected: isDefined(node.selected) ? signal(node.selected) : undefined,
     };

--- a/projects/ngx-vflow-lib/src/lib/vflow/models/node.model.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/models/node.model.ts
@@ -60,6 +60,8 @@ export class NodeModel<T = unknown>
 
   public preview = signal<NodePreview>({ style: {} });
 
+  public extent = signal<'parent' | null>(NODE_DEFAULTS.extent);
+
   public globalPoint = computed(() => {
     let parent = this.parent();
     let x = this.point().x;
@@ -181,6 +183,10 @@ export class NodeModel<T = unknown>
 
     if (rawNode.selected) {
       this.selected = rawNode.selected;
+    }
+
+    if (rawNode.extent) {
+      this.extent = rawNode.extent;
     }
 
     if (rawNode.type === 'default-group' && rawNode.color) {

--- a/projects/ngx-vflow-lib/src/lib/vflow/services/draggable.service.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/services/draggable.service.ts
@@ -121,8 +121,9 @@ export class DraggableService {
    */
   private moveNode(model: NodeModel, point: Point) {
     const parent = model.parent();
+
     // keep node in bounds of parent
-    if (parent) {
+    if (model.extent() === 'parent' && parent) {
       point.x = Math.min(parent.width() - model.width(), point.x);
       point.x = Math.max(0, point.x);
 


### PR DESCRIPTION
This PR adds a grid background pattern.

<img width="763" height="501" alt="image" src="https://github.com/user-attachments/assets/9cfcd602-d21c-4bbb-92fc-dad3c21862c1" />

Had to change the variables a bit in `background.component.ts` to make them reusable for the new grid background