### PR TITLE
fix: improve performance when adding nodes

### DIFF
--- a/projects/ngx-vflow-lib/src/lib/vflow/models/node.model.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/models/node.model.ts
@@ -130,9 +130,14 @@ export class NodeModel<T = unknown>
     node: this.rawNode,
   };
 
-  public parent = computed(() => this.entitiesService.nodes().find((n) => n.rawNode.id === this.parentId()) ?? null);
+  public parent = computed(() => {
+    const parentId = this.parentId();
+    if (!parentId) return null;
 
-  public children = computed(() => this.entitiesService.nodes().filter((n) => n.parentId() === this.rawNode.id));
+    return this.entitiesService.nodeByIdMap().get(parentId) ?? null;
+  });
+
+  public children = computed(() => this.entitiesService.nodesByParentIdMap().get(this.rawNode.id) ?? []);
 
   public color = signal(NODE_DEFAULTS.color);
 

--- a/projects/ngx-vflow-lib/src/lib/vflow/services/flow-entities.service.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/services/flow-entities.service.ts
@@ -15,6 +15,32 @@ export class FlowEntitiesService {
     equal: (a, b) => (!a.length && !b.length ? true : a === b),
   });
 
+  public readonly nodeByIdMap = computed(() => {
+    const result = new Map<string, NodeModel>();
+    this.nodes().forEach((x) => {
+      result.set(x.rawNode.id, x);
+    });
+    return result;
+  });
+
+  public readonly nodesByParentIdMap = computed(() => {
+    const result = new Map<string, NodeModel[]>();
+    this.nodes().forEach((x) => {
+      if (!x.rawNode.parentId) return;
+      const parentId = x.rawNode.parentId();
+      if (!parentId) return;
+
+      const nodes = result.get(parentId);
+      if (nodes) {
+        nodes.push(x);
+        result.set(parentId, nodes);
+      } else {
+        result.set(parentId, [x]);
+      }
+    });
+    return result;
+  });
+
   public readonly rawNodes = computed(() => this.nodes().map((n) => n.rawNode) as Node[]);
 
   public readonly edges = signal<EdgeModel[]>([], {

--- a/projects/ngx-vflow-lib/src/lib/vflow/services/node-rendering.service.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/services/node-rendering.service.ts
@@ -14,6 +14,7 @@ export class NodeRenderingService {
   private flowEntitiesService = inject(FlowEntitiesService);
   private flowSettingsService = inject(FlowSettingsService);
   private viewportService = inject(ViewportService);
+  private maxOrder = 0;
 
   public readonly nodes = computed(() => {
     if (!this.flowSettingsService.optimization().virtualization) {
@@ -69,13 +70,10 @@ export class NodeRenderingService {
     },
   );
 
-  private maxOrder = computed(() => {
-    return Math.max(...this.flowEntitiesService.nodes().map((n) => n.renderOrder()));
-  });
-
   public pullNode(node: NodeModel) {
+    this.maxOrder++;
     // pull node
-    node.renderOrder.set(this.maxOrder() + 1);
+    node.renderOrder.set(this.maxOrder);
 
     // pull children
     node.children().forEach((n) => this.pullNode(n));

--- a/projects/ngx-vflow-lib/src/lib/vflow/utils/is-callable.ts
+++ b/projects/ngx-vflow-lib/src/lib/vflow/utils/is-callable.ts
@@ -1,8 +1,6 @@
-export function isCallable(fn: any): boolean {
-  try {
-    new Proxy(fn, { apply: () => undefined })();
-    return true;
-  } catch (err) {
-    return false;
-  }
+import { StaticNode } from '../interfaces/node.interface';
+
+export function isCallable<T = any>(type: StaticNode<T>['type'] | any): boolean {
+  if (typeof type !== 'function') return false;
+  return type.apply !== undefined;
 }


### PR DESCRIPTION
Improved performances when adding nodes.

The performance traces were taken in the existing demo page `/performance/stress-test` and `/performance/virtualization`

Virtualization page load went from ~ 6000ms -> ~890ms for the trace bellow
[virtualization before](https://github.com/user-attachments/files/25133109/virtualization_before_6000ms_Trace-20260206T114546.json.gz)
[virtualization after](https://github.com/user-attachments/files/25133114/virtualization_after_890ms_Trace-20260206T113117.json.gz)

Stress test page load went from ~3600ms -> ~2850ms for the trace bellow
[stress test before](https://github.com/user-attachments/files/25133133/stress_test_before_3600ms_Trace-20260206T114757.json.gz)
[stress test after](https://github.com/user-attachments/files/25133139/stress_test_after_2850ms_Trace-20260206T114919.json.gz)


